### PR TITLE
Distribute missing headers in src/Makefile.am

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -39,4 +39,6 @@ opentegra_drv_la_SOURCES = \
 	drmmode_display.c \
 	drmmode_display.h \
 	exa.c \
+	exa.h \
+	host1x.h \
 	xv.c


### PR DESCRIPTION
This commit in made on top of master in order to keep xv.c
