### PR TITLE
exa: use tegra_stream for commands submission

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -43,4 +43,6 @@ opentegra_drv_la_SOURCES = \
 	exa.c \
 	exa.h \
 	vblank.c \
-	vblank.h
+	vblank.h \
+	tegra_stream.c \
+	tegra_stream.h

--- a/src/exa.h
+++ b/src/exa.h
@@ -29,11 +29,11 @@
 
 #include <libdrm/tegra.h>
 
+#include "tegra_stream.h"
+
 typedef struct _TegraEXARec{
-    struct drm_tegra_pushbuf *pushbuf;
     struct drm_tegra_channel *gr2d;
-    struct drm_tegra_job *job;
-    struct drm_tegra_bo *bo;
+    struct tegra_stream cmds;
 
     ExaDriverPtr driver;
 } *TegraEXAPtr;

--- a/src/tegra_stream.c
+++ b/src/tegra_stream.c
@@ -1,0 +1,434 @@
+/*
+ * Copyright (c) 2016-2017 Dmitry Osipenko <digetx@gmail.com>
+ * Copyright (C) 2012-2013 NVIDIA Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS\n", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * Authors:
+ *    Arto Merilainen <amerilainen@nvidia.com>
+ */
+
+#include "xorg-server.h"
+#include "xf86.h"
+
+#include "host1x.h"
+#include "tegra_stream.h"
+
+#define ErrorMsg(fmt, args...) \
+    xf86DrvMsg(-1, X_ERROR, "%s:%d/%s(): " fmt, \
+               __FILE__, __LINE__, __func__, ##args)
+
+/*
+ * Default configuration for new streams
+ *
+ * DEFAULT_BUFFER_SIZE_WORDS - Define the size of command buffer
+ */
+
+#define DEFAULT_BUFFER_SIZE_WORDS   8192
+
+/*
+ * tegra_release_cmdbuf(buffer)
+ *
+ * This function releases given command buffer.
+ */
+
+static void tegra_release_cmdbuf(struct tegra_command_buffer *buffer)
+{
+    drm_tegra_bo_unmap(buffer->bo);
+    drm_tegra_bo_unref(buffer->bo);
+}
+
+/*
+ * tegra_allocate_cmdbuf(buffer)
+ *
+ * This function allocates and initializes a command buffer.
+ */
+
+static int tegra_allocate_cmdbuf(struct drm_tegra *drm,
+                                 struct tegra_command_buffer *buffer,
+                                 uint32_t words_num)
+{
+    void *stub;
+    int ret;
+
+    /* Allocate and map memory for opcodes. */
+
+    ret = drm_tegra_bo_new(&buffer->bo, drm, 0, sizeof(uint32_t) * words_num);
+    if (ret) {
+        ErrorMsg("drm_tegra_bo_new() failed %d\n", ret);
+        return ret;
+    }
+
+    /* Bump mmap refcount to avoid expensive CMA re-mappings. */
+
+    ret = drm_tegra_bo_map(buffer->bo, &stub);
+    if (ret) {
+        ErrorMsg("drm_tegra_bo_map() failed %d\n", ret);
+        drm_tegra_bo_unref(buffer->bo);
+    }
+
+    return ret;
+}
+
+/*
+ * tegra_stream_create(channel)
+ *
+ * Create a stream for given channel. This function preallocates several
+ * command buffers for later usage to improve performance. Streams are
+ * used for generating command buffers opcode by opcode using
+ * tegra_stream_push().
+ */
+
+int tegra_stream_create(struct drm_tegra *drm,
+                        struct drm_tegra_channel *channel,
+                        struct tegra_stream *stream,
+                        uint32_t words_num)
+{
+    words_num = words_num ? words_num : DEFAULT_BUFFER_SIZE_WORDS;
+
+    stream->status      = TEGRADRM_STREAM_FREE;
+    stream->buffer_size = words_num;
+    stream->channel     = channel;
+
+    if (tegra_allocate_cmdbuf(drm, &stream->buffer, words_num))
+        goto err_buffer_alloc;
+
+    return 0;
+
+err_buffer_alloc:
+    tegra_release_cmdbuf(&stream->buffer);
+    return -1;
+}
+
+/*
+ * tegra_stream_destroy(stream)
+ *
+ * Destroy the given stream object. All resrouces are released.
+ */
+
+void tegra_stream_destroy(struct tegra_stream *stream)
+{
+    if (!stream)
+        return;
+
+    tegra_release_cmdbuf(&stream->buffer);
+    drm_tegra_job_free(stream->job);
+}
+
+/*
+ * tegra_stream_flush(stream, fence)
+ *
+ * Send the current contents of stream buffer. The stream must be
+ * synchronized correctly (we cannot send partial streams). If
+ * pointer to fence is given, the fence will contain the syncpoint value
+ * that is reached when operations in the buffer are finished.
+ */
+
+int tegra_stream_flush(struct tegra_stream *stream)
+{
+    struct drm_tegra_fence *fence;
+    int result = 0;
+
+    if (!stream)
+        return -1;
+
+    /* Reflushing is fine */
+    if (stream->status == TEGRADRM_STREAM_FREE)
+        return 0;
+
+    /* Return error if stream is constructed badly */
+    if (stream->status != TEGRADRM_STREAM_READY) {
+        result = -1;
+        goto cleanup;
+    }
+
+    result = drm_tegra_job_submit(stream->job, &fence);
+    if (result != 0) {
+        ErrorMsg("drm_tegra_job_submit() failed %d\n", result);
+        result = -1;
+        goto cleanup;
+    }
+
+    result = drm_tegra_fence_wait_timeout(fence, 1000);
+    if (result != 0) {
+        ErrorMsg("drm_tegra_fence_wait_timeout() failed %d\n", result);
+        result = -1;
+    }
+
+    drm_tegra_fence_free(fence);
+
+cleanup:
+    drm_tegra_job_free(stream->job);
+
+    stream->job = NULL;
+    stream->status = TEGRADRM_STREAM_FREE;
+
+    return result;
+}
+
+/*
+ * tegra_stream_begin(stream, num_words, fence, num_fences, num_syncpt_incrs,
+ *          num_relocs, class_id)
+ *
+ * Start constructing a stream.
+ *  - num_words refer to the maximum number of words the stream can contain.
+ *  - fence is a pointer to a table that contains syncpoint preconditions
+ *    before the stream execution can start.
+ *  - num_fences indicate the number of elements in the fence table.
+ *  - num_relocs indicate the number of memory references in the buffer.
+ *  - class_id refers to the class_id that is selected in the beginning of a
+ *    stream. If no class id is given, the default class id (=usually the
+ *    client device's class) is selected.
+ *
+ * This function verifies that the current buffer has enough room for holding
+ * the whole stream (this is computed using num_words and num_relocs). The
+ * function blocks until the stream buffer is ready for use.
+ */
+
+int tegra_stream_begin(struct tegra_stream *stream)
+{
+    int ret;
+
+    /* check stream and its state */
+    if (!(stream && stream->status == TEGRADRM_STREAM_FREE)) {
+        ErrorMsg("Stream status isn't FREE\n");
+        return -1;
+    }
+
+    ret = drm_tegra_job_new(&stream->job, stream->channel);
+    if (ret != 0) {
+        ErrorMsg("drm_tegra_job_new() failed %d\n", ret);
+        return -1;
+    }
+
+    ret = drm_tegra_pushbuf_new(&stream->buffer.pushbuf, stream->job,
+                                stream->buffer.bo, 0);
+    if (ret != 0) {
+        ErrorMsg("drm_tegra_pushbuf_new() failed %d\n", ret);
+        drm_tegra_job_free(stream->job);
+        return -1;
+    }
+
+    stream->class_id = 0;
+    stream->status = TEGRADRM_STREAM_CONSTRUCT;
+
+    /* include following in num words:
+     *  - syncpoint increment at the end of the stream (2 words)
+     */
+    stream->num_words = stream->buffer_size - 2;
+
+    return 0;
+}
+
+/*
+ * tegra_stream_push_reloc(stream, h, offset)
+ *
+ * Push a memory reference to the stream.
+ */
+
+int tegra_stream_push_reloc(struct tegra_stream *stream,
+                            struct drm_tegra_bo *bo,
+                            unsigned offset)
+{
+    int ret;
+
+    if (!(stream && stream->status == TEGRADRM_STREAM_CONSTRUCT)) {
+        ErrorMsg("Stream status isn't CONSTRUCT\n");
+        return -1;
+    }
+
+    if (stream->num_words == 0) {
+        stream->status = TEGRADRM_STREAM_CONSTRUCTION_FAILED;
+        ErrorMsg("Commands buffer is full\n");
+        return -1;
+    }
+
+    ret = drm_tegra_pushbuf_relocate(stream->buffer.pushbuf,
+                                     bo, offset, 0);
+    if (ret != 0) {
+        stream->status = TEGRADRM_STREAM_CONSTRUCTION_FAILED;
+        ErrorMsg("drm_tegra_pushbuf_relocate() failed %d\n", ret);
+        return -1;
+    }
+
+    stream->num_words--;
+    *stream->buffer.pushbuf->ptr++ = 0xDEADBEEF;
+
+    return 0;
+}
+
+/*
+ * tegra_stream_push(stream, word)
+ *
+ * Push a single word to given stream.
+ */
+
+int tegra_stream_push(struct tegra_stream *stream, uint32_t word)
+{
+    if (!(stream && stream->status == TEGRADRM_STREAM_CONSTRUCT)) {
+        ErrorMsg("Stream status isn't CONSTRUCT\n");
+        return -1;
+    }
+
+    if (stream->num_words == 0) {
+        stream->status = TEGRADRM_STREAM_CONSTRUCTION_FAILED;
+        ErrorMsg("Commands buffer is full\n");
+        return -1;
+    }
+
+    stream->num_words--;
+    *stream->buffer.pushbuf->ptr++ = word;
+
+    return 0;
+}
+
+/*
+ * tegra_stream_push_setclass(stream, class_id)
+ *
+ * Push "set class" opcode to the stream. Do nothing if the class is already
+ * active
+ */
+
+int tegra_stream_push_setclass(struct tegra_stream *stream, unsigned class_id)
+{
+    int result;
+
+    if (stream->class_id == class_id)
+        return 0;
+
+    result = tegra_stream_push(stream, HOST1X_OPCODE_SETCL(0, class_id, 0));
+
+    if (result == 0)
+        stream->class_id = class_id;
+
+    return result;
+}
+
+/*
+ * tegra_stream_end(stream)
+ *
+ * Mark end of stream. This function pushes last syncpoint increment for
+ * marking end of stream.
+ */
+
+int tegra_stream_end(struct tegra_stream *stream)
+{
+    int ret;
+
+    if (!(stream && stream->status == TEGRADRM_STREAM_CONSTRUCT)) {
+        ErrorMsg("Stream status isn't CONSTRUCT\n");
+        return -1;
+    }
+
+    if (stream->num_words == stream->buffer_size) {
+        stream->status = TEGRADRM_STREAM_CONSTRUCTION_FAILED;
+        ErrorMsg("Commands buffer is full\n");
+        return -1;
+    }
+
+    ret = drm_tegra_pushbuf_sync(stream->buffer.pushbuf,
+                                 DRM_TEGRA_SYNCPT_COND_OP_DONE);
+    if (ret != 0) {
+        stream->status = TEGRADRM_STREAM_CONSTRUCTION_FAILED;
+        ErrorMsg("drm_tegra_pushbuf_sync() failed %d\n", ret);
+        return -1;
+    }
+
+    stream->status = TEGRADRM_STREAM_READY;
+
+    return 0;
+}
+
+/*
+ * tegra_reloc (variable, handle, offset)
+ *
+ * This function creates a reloc allocation. The function should be used in
+ * conjunction with tegra_stream_push_words.
+ */
+
+struct tegra_reloc tegra_reloc(const void *var_ptr, struct drm_tegra_bo *bo,
+                               uint32_t offset, uint32_t var_offset)
+{
+    struct tegra_reloc reloc = {var_ptr, bo, offset, var_offset};
+    return reloc;
+}
+
+/*
+ * tegra_stream_push_words(stream, addr, words, ...)
+ *
+ * Push words from given address to stream. The function takes
+ * reloc structs as its argument. You can generate the structs with tegra_reloc
+ * function.
+ */
+
+int tegra_stream_push_words(struct tegra_stream *stream, const void *addr,
+                            unsigned words, int num_relocs, ...)
+{
+    struct tegra_reloc reloc_arg;
+    va_list ap;
+    uint32_t *pushbuf_ptr;
+    int ret;
+
+    if (!(stream && stream->status == TEGRADRM_STREAM_CONSTRUCT)) {
+        ErrorMsg("Stream status isn't CONSTRUCT\n");
+        return -1;
+    }
+
+    if (stream->num_words < words) {
+        stream->status = TEGRADRM_STREAM_CONSTRUCTION_FAILED;
+        ErrorMsg("Commands buffer is full\n");
+        return -1;
+    }
+
+    /* Class id should be set explicitly, for simplicity. */
+    if (stream->class_id == 0) {
+        stream->status = TEGRADRM_STREAM_CONSTRUCTION_FAILED;
+        ErrorMsg("HOST1X class not specified\n");
+        return -1;
+    }
+
+    stream->num_words -= words;
+
+    /* Copy the contents */
+    pushbuf_ptr = stream->buffer.pushbuf->ptr;
+    memcpy(pushbuf_ptr, addr, words * sizeof(uint32_t));
+
+    /* Copy relocs */
+    va_start(ap, num_relocs);
+    for (; num_relocs; num_relocs--) {
+        reloc_arg = va_arg(ap, struct tegra_reloc);
+
+        stream->buffer.pushbuf->ptr  = pushbuf_ptr;
+        stream->buffer.pushbuf->ptr += reloc_arg.var_offset / sizeof(uint32_t);
+
+        ret = drm_tegra_pushbuf_relocate(stream->buffer.pushbuf, reloc_arg.bo,
+                                         reloc_arg.offset, 0);
+        if (ret != 0) {
+            stream->status = TEGRADRM_STREAM_CONSTRUCTION_FAILED;
+            ErrorMsg("drm_tegra_pushbuf_relocate() failed %d\n", ret);
+            break;
+        }
+    }
+    va_end(ap);
+
+    stream->buffer.pushbuf->ptr = pushbuf_ptr + words;
+
+    return ret ? -1 : 0;
+}

--- a/src/tegra_stream.h
+++ b/src/tegra_stream.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2016-2017 Dmitry Osipenko <digetx@gmail.com>
+ * Copyright (C) 2012-2013 NVIDIA Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * Authors:
+ *	Arto Merilainen <amerilainen@nvidia.com>
+ */
+
+#ifndef TEGRA_STREAM_H_
+#define TEGRA_STREAM_H_
+
+#include <stdint.h>
+#include <libdrm/tegra.h>
+
+enum tegra_stream_status {
+    TEGRADRM_STREAM_FREE,
+    TEGRADRM_STREAM_CONSTRUCT,
+    TEGRADRM_STREAM_CONSTRUCTION_FAILED,
+    TEGRADRM_STREAM_READY,
+};
+
+struct tegra_command_buffer {
+    struct drm_tegra_bo *bo;
+    struct drm_tegra_pushbuf *pushbuf;
+};
+
+struct tegra_stream {
+    enum tegra_stream_status status;
+
+    struct drm_tegra_job *job;
+    struct drm_tegra_channel *channel;
+
+    struct tegra_command_buffer buffer;
+    int num_words;
+    uint32_t buffer_size;
+    uint32_t class_id;
+};
+
+struct tegra_reloc {
+    const void *addr;
+    struct drm_tegra_bo *bo;
+    uint32_t offset;
+    unsigned var_offset;
+};
+
+/* Stream operations */
+int tegra_stream_create(struct drm_tegra *drm,
+                        struct drm_tegra_channel *channel,
+                        struct tegra_stream *stream,
+                        uint32_t words_num);
+void tegra_stream_destroy(struct tegra_stream *stream);
+int tegra_stream_begin(struct tegra_stream *stream);
+int tegra_stream_end(struct tegra_stream *stream);
+int tegra_stream_flush(struct tegra_stream *stream);
+int tegra_stream_push(struct tegra_stream *stream, uint32_t word);
+int tegra_stream_push_setclass(struct tegra_stream *stream, unsigned class_id);
+int tegra_stream_push_reloc(struct tegra_stream *stream,
+                            struct drm_tegra_bo *bo, unsigned offset);
+struct tegra_reloc tegra_reloc(const void *var_ptr, struct drm_tegra_bo *bo,
+                               uint32_t offset, uint32_t var_offset);
+int tegra_stream_push_words(struct tegra_stream *stream, const void *addr,
+                            unsigned words, int num_relocs, ...);
+
+#endif


### PR DESCRIPTION
I have got a couple of kernel crashes which were caused by a commands pushbuf
overflow. We are not checking whether there is some space left in the pushbuf
before adding a new command to it, the tegra_stream addresses this shortcoming
and also makes code a bit cleaner. It is definitely a kernel bug as well, there
shouldn't be a crash on a command stream dump.

[  179.285724] ---- syncpts ----
[  179.285738] id 0 (00-(null)) min 13383 max 13446
[  179.285753] id 3 (03-54200000.dc) min 10799 max 0

[  179.285802] ---- channels ----
[  179.285811] 0: fifo:
[  179.285821] FIFOSTAT 80100c40
[  179.285827] [empty]
[  179.285839] 0-54140000.gr2d:
[  179.285853] active class 51, offset 0000, val 20000000
[  179.285865] DMAPUT 00000168, DMAGET 00000168, DMACTL 00000000
[  179.285876] CBREAD 20000000, CBSTAT 00510000
[  179.285898]
               ee63ea00: JOB, syncpt_id=0, syncpt_val=13446, first_get=00000150, timeout=1000 num_slots=3, num_handles=3
[  179.285914]     GATHER at 0x3c059000+0x0, 1589 words
[  179.285923] 3c059000: 00001440:
[  179.285933] SETCL(class=051)
[  179.285942] 3c059004: 30090009:
[  179.285952] MASK(offset=009, mask=009, [
[  179.285961] 0000003a,
[  179.285969] 00000000,
[  179.285979] 3c059010: 301e0005:
[  179.285989] MASK(offset=01e, mask=005, [
[  179.285998] 00000000,
[  179.286006] 000000cc,
[  179.286015] 3c05901c: 20460001:
[  179.286023] NONINCR(offset=046, [
[  179.286031] 00000000,
[  179.286040] 3c059024: 302b0149:
[  179.286050] MASK(offset=02b, mask=149, [
[  179.286058] 3d800000,
[  179.286066] 000013d0,
[  179.286073] 3d400000,
[  179.286081] 00001400,
[  179.286090] 3c059038: 101f0001:
[  179.286098] INCR(offset=01f, [
[  179.286106] 00120000,
[  179.286115] 3c059040: 10370004:
[  179.286123] INCR(offset=037, [
[  179.286131] 00010283,
[  179.286139] 00010283,
[  179.286147] 0023000f,
[  179.286154] 00000000,
[  179.286163] 3c059054: 20000001:
[  179.286171] NONINCR(offset=000, [
[  179.286178] 00000100,
[  179.286187] 3c05905c: 101f0001:
[  179.286195] INCR(offset=01f, [
[  179.286203] 00120000,

....

[  179.296888] 3c059ff0: 20000001:
[  179.296896] NONINCR(offset=000, [
[  179.296903] 00000100,
[  179.296911] 3c059ff8: 101f0001:
[  179.296919] INCR(offset=01f, [
[  179.296927] 00120000,
[  179.296946] Unable to handle kernel paging request at virtual address f0a7e000
[  179.296954] pgd = c0004000
[  179.296962] [f0a7e000] *pgd=2e912811, *pte=00000000, *ppte=00000000