### PR TITLE
exa: reduce commands buffer size

### DIFF
--- a/src/exa.c
+++ b/src/exa.c
@@ -486,7 +486,7 @@ void TegraEXAScreenInit(ScreenPtr pScreen)
         goto free_priv;
     }
 
-    err = tegra_stream_create(tegra->drm, priv->gr2d, &priv->cmds, 32768);
+    err = tegra_stream_create(tegra->drm, priv->gr2d, &priv->cmds, 16384);
     if (err < 0) {
         ErrorMsg("failed to create command stream: %d\n", err);
         goto close_gr2d;

--- a/src/tegra_stream.c
+++ b/src/tegra_stream.c
@@ -107,6 +107,11 @@ int tegra_stream_create(struct drm_tegra *drm,
     stream->buffer_size = words_num;
     stream->channel     = channel;
 
+    if (words_num > 16384) {
+        ErrorMsg("Maximum number of words is 16384\n");
+        return -1;
+    }
+
     if (tegra_allocate_cmdbuf(drm, &stream->buffer, words_num))
         goto err_buffer_alloc;
 


### PR DESCRIPTION
The maximum number of a HOST1X gather fetches is 16384, a higher value
would result in an integer overflow on CDMA submission. If we'd need to
submit a higher number of words, an additional pushbufs should be used for
the job.