### PR TITLE
exa: reduce commands buffer size by one

### DIFF
--- a/src/exa.c
+++ b/src/exa.c
@@ -486,7 +486,7 @@ void TegraEXAScreenInit(ScreenPtr pScreen)
         goto free_priv;
     }
 
-    err = tegra_stream_create(tegra->drm, priv->gr2d, &priv->cmds, 16384);
+    err = tegra_stream_create(tegra->drm, priv->gr2d, &priv->cmds, 16383);
     if (err < 0) {
         ErrorMsg("failed to create command stream: %d\n", err);
         goto close_gr2d;

--- a/src/tegra_stream.c
+++ b/src/tegra_stream.c
@@ -107,8 +107,8 @@ int tegra_stream_create(struct drm_tegra *drm,
     stream->buffer_size = words_num;
     stream->channel     = channel;
 
-    if (words_num > 16384) {
-        ErrorMsg("Maximum number of words is 16384\n");
+    if (words_num > 16383) {
+        ErrorMsg("Maximum number of words is 16383\n");
         return -1;
     }
 


### PR DESCRIPTION
The gather maximum words count is 16383, not 16384.