### PR TITLE
Use CFLAGS from configure not from env

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -24,7 +24,7 @@
 # _ladir passes a dummy rpath to libtool so the thing will actually link
 # TODO: -nostdlib/-Bstatic/-lgcc platform magic, not installing the .a, etc.
 
-AM_CFLAGS = $(XORG_CFLAGS) $(DRM_CFLAGS) $(UDEV_CFLAGS) $(CWARNFLAGS)
+AM_CFLAGS = @XORG_CFLAGS@ @DRM_CFLAGS@ @UDEV_CFLAGS@ @CWARNFLAGS@
 
 opentegra_drv_la_LTLIBRARIES = opentegra_drv.la
 opentegra_drv_la_LDFLAGS = -module -avoid-version


### PR DESCRIPTION
It doesn't seem to produce any changes anyway
It's just usual to use this form with autotools.

Signed-off-by: Nicolas Chauvet <kwizart@gmail.com>