### PR TITLE
MATE crash fix

### DIFF
--- a/src/driver.c
+++ b/src/driver.c
@@ -171,7 +171,7 @@ FreeRec(ScrnInfoPtr pScrn)
         return;
     pScrn->driverPrivate = NULL;
 
-    if (tegra->fd > 0)
+    if (tegra->fd >= 0)
 #ifdef XF86_PDEV_SERVER_FD
         if (!(tegra->pEnt->location.type == BUS_PLATFORM &&
               (tegra->pEnt->location.id.plat->flags & XF86_PDEV_SERVER_FD)))
@@ -222,12 +222,11 @@ TegraOpenHardware(const char *dev)
     else {
         dev = getenv("KMSDEVICE");
         if ((dev == NULL) || ((fd = open(dev, O_RDWR, 0)) == -1)) {
-            dev = "/dev/dri/card0";
-            fd = open(dev,O_RDWR, 0);
+            fd = drmOpen("tegra", NULL);
         }
     }
 
-    if (fd == -1)
+    if (fd < 0)
         xf86DrvMsg(-1, X_ERROR, "open %s: %s\n", dev, strerror(errno));
 
     return fd;
@@ -248,7 +247,7 @@ TegraProbeHardware(const char *dev, struct xf86_platform_device *platform_dev)
 #endif
 
     fd = TegraOpenHardware(dev);
-    if (fd != -1) {
+    if (fd >= 0) {
         close(fd);
         return TRUE;
     }

--- a/src/drmmode_display.c
+++ b/src/drmmode_display.c
@@ -808,7 +808,8 @@ drmmode_output_set_property(xf86OutputPtr output, Atom property,
                 return FALSE;
 
             memcpy(&atom, value->data, 4);
-            name = NameForAtom(atom);
+            if (!(name = NameForAtom(atom)))
+                return FALSE;
 
             /* search for matching name string, then set its value down */
             for (j = 0; j < p->mode_prop->count_enums; j++) {

--- a/src/drmmode_display.c
+++ b/src/drmmode_display.c
@@ -780,6 +780,9 @@ drmmode_output_set_property(xf86OutputPtr output, Atom property,
     for (i = 0; i < drmmode_output->num_props; i++) {
         drmmode_prop_ptr p = &drmmode_output->props[i];
 
+        if (!p->atoms)
+            continue;
+
         if (p->atoms[0] != property)
             continue;
 


### PR DESCRIPTION
MATE Desktop Environment causes a Xorg crash, probably some new DRM mode property type is used now (or been added) casing a NULL dereference in Opentegra. Another minor change is the drmOpen usage which would avoid wrong device opening in case of modular Tegra DRM kernel driver as there could be other DRM device module loaded earlier.