### PR TITLE
exa: implement TegraEXAMarkSync / TegraEXAWaitMarker

### DIFF
--- a/src/exa.c
+++ b/src/exa.c
@@ -60,14 +60,17 @@ static inline unsigned int TegraEXAPitch(unsigned int width, unsigned int bpp)
 
 static int TegraEXAMarkSync(ScreenPtr pScreen)
 {
-    /* TODO: implement */
+    ScrnInfoPtr pScrn = xf86ScreenToScrn(pScreen);
+    TegraEXAPtr tegra = TegraPTR(pScrn)->exa;
 
-    return 0;
+    /* yes, we are converting pointer to integer, it is fine on ARM */
+    return (intptr_t) ((void *) tegra_stream_get_fence(&tegra->cmds));
 }
 
 static void TegraEXAWaitMarker(ScreenPtr pScreen, int marker)
 {
-    /* TODO: implement */
+    struct drm_tegra_fence *fence = (void *) marker;
+    tegra_stream_put_fence(fence);
 }
 
 static Bool TegraEXAPrepareAccess(PixmapPtr pPix, int idx)
@@ -282,7 +285,7 @@ static void TegraEXADoneSolid(PixmapPtr pPixmap)
     TegraEXAPtr tegra = TegraPTR(pScrn)->exa;
 
     tegra_stream_end(&tegra->cmds);
-    tegra_stream_flush(&tegra->cmds);
+    tegra_stream_submit(&tegra->cmds);
 }
 
 static Bool TegraEXAPrepareCopy(PixmapPtr pSrcPixmap, PixmapPtr pDstPixmap,
@@ -397,7 +400,7 @@ static void TegraEXADoneCopy(PixmapPtr pDstPixmap)
     TegraEXAPtr tegra = TegraPTR(pScrn)->exa;
 
     tegra_stream_end(&tegra->cmds);
-    tegra_stream_flush(&tegra->cmds);
+    tegra_stream_submit(&tegra->cmds);
 }
 
 static Bool TegraEXACheckComposite(int op, PicturePtr pSrcPicture,

--- a/src/exa.c
+++ b/src/exa.c
@@ -262,8 +262,10 @@ static Bool TegraEXAPrepareSolid(PixmapPtr pPixmap, int op, Pixel planemask,
     tegra_stream_push(&tegra->cmds, HOST1X_OPCODE_NONINCR(0x46, 1));
     tegra_stream_push(&tegra->cmds, 0); /* non-tiled */
 
-    if (tegra->cmds.status != TEGRADRM_STREAM_CONSTRUCT)
-            return FALSE;
+    if (tegra->cmds.status != TEGRADRM_STREAM_CONSTRUCT) {
+        tegra_stream_cleanup(&tegra->cmds);
+        return FALSE;
+    }
 
     return TRUE;
 }
@@ -352,8 +354,10 @@ static Bool TegraEXAPrepareCopy(PixmapPtr pSrcPixmap, PixmapPtr pDstPixmap,
     tegra_stream_push(&tegra->cmds,
                       exaGetPixmapPitch(pSrcPixmap)); /* srcst */
 
-    if (tegra->cmds.status != TEGRADRM_STREAM_CONSTRUCT)
-            return FALSE;
+    if (tegra->cmds.status != TEGRADRM_STREAM_CONSTRUCT) {
+        tegra_stream_cleanup(&tegra->cmds);
+        return FALSE;
+    }
 
     return TRUE;
 }

--- a/src/tegra_stream.c
+++ b/src/tegra_stream.c
@@ -67,6 +67,7 @@ void tegra_stream_destroy(struct tegra_stream *stream)
     if (!stream)
         return;
 
+    drm_tegra_fence_free(stream->fence);
     drm_tegra_job_free(stream->job);
 }
 
@@ -86,6 +87,13 @@ int tegra_stream_flush(struct tegra_stream *stream)
 
     if (!stream)
         return -1;
+
+    /* Flush previously submitted async job if any */
+    if (stream->fence) {
+        drm_tegra_fence_wait_timeout(stream->fence, 1000);
+        drm_tegra_fence_free(stream->fence);
+        stream->fence = NULL;
+    }
 
     /* Reflushing is fine */
     if (stream->status == TEGRADRM_STREAM_FREE)
@@ -119,6 +127,66 @@ cleanup:
     stream->status = TEGRADRM_STREAM_FREE;
 
     return result;
+}
+
+int tegra_stream_submit(struct tegra_stream *stream)
+{
+    int result = 0;
+
+    if (!stream)
+        return -1;
+
+    /* Destroy previously submitted, but unused jobs fence */
+    drm_tegra_fence_free(stream->fence);
+    stream->fence = NULL;
+
+    /* Resubmitting is fine */
+    if (stream->status == TEGRADRM_STREAM_FREE)
+        return 0;
+
+    /* Return error if stream is constructed badly */
+    if (stream->status != TEGRADRM_STREAM_READY) {
+        result = -1;
+        goto cleanup;
+    }
+
+    result = drm_tegra_job_submit(stream->job, &stream->fence);
+    if (result != 0) {
+        ErrorMsg("drm_tegra_job_submit() failed %d\n", result);
+        result = -1;
+    }
+
+cleanup:
+    drm_tegra_job_free(stream->job);
+
+    stream->job = NULL;
+    stream->status = TEGRADRM_STREAM_FREE;
+
+    return result;
+}
+
+struct drm_tegra_fence * tegra_stream_get_fence(struct tegra_stream *stream)
+{
+    struct drm_tegra_fence *fence;
+
+    if (!stream)
+        return NULL;
+
+    fence = stream->fence;
+    /* this fence isn't ours anymore */
+    stream->fence = NULL;
+
+    return fence;
+}
+
+void tegra_stream_put_fence(struct drm_tegra_fence *fence)
+{
+    int result = drm_tegra_fence_wait_timeout(fence, 1000);
+    if (result != 0) {
+        ErrorMsg("drm_tegra_fence_wait_timeout() failed %d\n", result);
+    }
+
+    drm_tegra_fence_free(fence);
 }
 
 /*

--- a/src/tegra_stream.c
+++ b/src/tegra_stream.c
@@ -71,6 +71,21 @@ void tegra_stream_destroy(struct tegra_stream *stream)
     drm_tegra_job_free(stream->job);
 }
 
+int tegra_stream_cleanup(struct tegra_stream *stream)
+{
+    if (!stream)
+        return -1;
+
+    drm_tegra_fence_free(stream->fence);
+    drm_tegra_job_free(stream->job);
+
+    stream->job = NULL;
+    stream->fence = NULL;
+    stream->status = TEGRADRM_STREAM_FREE;
+
+    return 0;
+}
+
 /*
  * tegra_stream_flush(stream, fence)
  *
@@ -121,10 +136,7 @@ int tegra_stream_flush(struct tegra_stream *stream)
     drm_tegra_fence_free(fence);
 
 cleanup:
-    drm_tegra_job_free(stream->job);
-
-    stream->job = NULL;
-    stream->status = TEGRADRM_STREAM_FREE;
+    tegra_stream_cleanup(stream);
 
     return result;
 }

--- a/src/tegra_stream.h
+++ b/src/tegra_stream.h
@@ -69,6 +69,7 @@ int tegra_stream_create(struct drm_tegra *drm,
 void tegra_stream_destroy(struct tegra_stream *stream);
 int tegra_stream_begin(struct tegra_stream *stream);
 int tegra_stream_end(struct tegra_stream *stream);
+int tegra_stream_cleanup(struct tegra_stream *stream);
 int tegra_stream_flush(struct tegra_stream *stream);
 int tegra_stream_submit(struct tegra_stream *stream);
 struct drm_tegra_fence * tegra_stream_get_fence(struct tegra_stream *stream);

--- a/src/tegra_stream.h
+++ b/src/tegra_stream.h
@@ -47,6 +47,7 @@ struct tegra_stream {
 
     struct drm_tegra_job *job;
     struct drm_tegra_channel *channel;
+    struct drm_tegra_fence *fence;
 
     struct tegra_command_buffer buffer;
     int num_words;
@@ -69,6 +70,9 @@ void tegra_stream_destroy(struct tegra_stream *stream);
 int tegra_stream_begin(struct tegra_stream *stream);
 int tegra_stream_end(struct tegra_stream *stream);
 int tegra_stream_flush(struct tegra_stream *stream);
+int tegra_stream_submit(struct tegra_stream *stream);
+struct drm_tegra_fence * tegra_stream_get_fence(struct tegra_stream *stream);
+void tegra_stream_put_fence(struct drm_tegra_fence *fence);
 int tegra_stream_push(struct tegra_stream *stream, uint32_t word);
 int tegra_stream_push_setclass(struct tegra_stream *stream, unsigned class_id);
 int tegra_stream_push_reloc(struct tegra_stream *stream,


### PR DESCRIPTION
Potentially this should yield a better Xorg performance. The tegra_stream
has been extended with an async submission and fence get / put helpers,
get returns fence for the latest submitted job and put waits for a job
completion, freeing fence in the end.