### PR TITLE
modesetting: handle NULL cursor in drmmode_set_cursor.

### DIFF
--- a/src/drmmode_display.c
+++ b/src/drmmode_display.c
@@ -346,6 +346,9 @@ drmmode_set_cursor(xf86CrtcPtr crtc)
         xf86CrtcConfigPtr xf86_config = XF86_CRTC_CONFIG_PTR(crtc->scrn);
         CursorPtr cursor = xf86_config->cursor;
 
+        if (cursor == NullCursor)
+            return TRUE;
+
         ret =
             drmModeSetCursor2(drmmode->fd, drmmode_crtc->mode_crtc->crtc_id,
                               handle, tegra->cursor_width, tegra->cursor_height,


### PR DESCRIPTION
We had a bug reported with a touchscreen where we could end up
in here with a NULL cursor, so let's not crash the X server.

Signed-off-by: Dave Airlie <airlied@redhat.com>
Reviewed-and-Tested-by: Daniel Martin <consume.noise@gmail.com>
Signed-off-by: Peter Hutterer <peter.hutterer@who-t.net>