### PR TITLE
tegra_stream: compilation fix

### DIFF
--- a/src/tegra_stream.c
+++ b/src/tegra_stream.c
@@ -75,11 +75,9 @@ int tegra_stream_cleanup(struct tegra_stream *stream)
     if (!stream)
         return -1;
 
-    drm_tegra_fence_free(stream->fence);
     drm_tegra_job_free(stream->job);
 
     stream->job = NULL;
-    stream->fence = NULL;
     stream->status = TEGRADRM_STREAM_FREE;
 
     return 0;


### PR DESCRIPTION
Commit 01f46bc (exa/tegra_stream: correctly prepare pushbuf) erroneously added
couple of unrelated lines of code that broke compilation, remove them.

Thanks to @dipolukarov for pointing to the bug.