### PR TITLE
exa/tegra_stream: increment syncpoint after each HW operation trigger

### DIFF
--- a/src/exa.c
+++ b/src/exa.c
@@ -277,6 +277,7 @@ static void TegraEXASolid(PixmapPtr pPixmap,
     tegra_stream_push(&tegra->cmds, HOST1X_OPCODE_MASK(0x38, 0x5));
     tegra_stream_push(&tegra->cmds, (py2 - py1) << 16 | (px2 - px1));
     tegra_stream_push(&tegra->cmds, py1 << 16 | px1);
+    tegra_stream_sync(&tegra->cmds, DRM_TEGRA_SYNCPT_COND_OP_DONE);
 }
 
 static void TegraEXADoneSolid(PixmapPtr pPixmap)
@@ -395,6 +396,7 @@ static void TegraEXACopy(PixmapPtr pDstPixmap, int srcX, int srcY, int dstX,
     tegra_stream_push(&tegra->cmds, height << 16 | width); /* dstsize */
     tegra_stream_push(&tegra->cmds, srcY << 16 | srcX); /* srcps */
     tegra_stream_push(&tegra->cmds, dstY << 16 | dstX); /* dstps */
+    tegra_stream_sync(&tegra->cmds, DRM_TEGRA_SYNCPT_COND_OP_DONE);
 }
 
 static void TegraEXADoneCopy(PixmapPtr pDstPixmap)

--- a/src/tegra_stream.c
+++ b/src/tegra_stream.c
@@ -184,6 +184,7 @@ int tegra_stream_begin(struct tegra_stream *stream)
 
     stream->class_id = 0;
     stream->status = TEGRADRM_STREAM_CONSTRUCT;
+    stream->op_done_synced = false;
 
     return 0;
 }
@@ -230,6 +231,7 @@ int tegra_stream_push(struct tegra_stream *stream, uint32_t word)
     }
 
     *stream->buffer.pushbuf->ptr++ = word;
+    stream->op_done_synced = false;
 
     return 0;
 }
@@ -272,6 +274,9 @@ int tegra_stream_end(struct tegra_stream *stream)
         return -1;
     }
 
+    if (stream->op_done_synced)
+        goto ready;
+
     ret = drm_tegra_pushbuf_sync(stream->buffer.pushbuf,
                                  DRM_TEGRA_SYNCPT_COND_OP_DONE);
     if (ret != 0) {
@@ -280,7 +285,9 @@ int tegra_stream_end(struct tegra_stream *stream)
         return -1;
     }
 
+ready:
     stream->status = TEGRADRM_STREAM_READY;
+    stream->op_done_synced = false;
 
     return 0;
 }
@@ -376,6 +383,29 @@ int tegra_stream_prep(struct tegra_stream *stream, uint32_t words)
         ErrorMsg("drm_tegra_pushbuf_prepare() failed %d\n", ret);
         return -1;
     }
+
+    return 0;
+}
+
+int tegra_stream_sync(struct tegra_stream *stream,
+                      enum drm_tegra_syncpt_cond cond)
+{
+    int ret;
+
+    if (!(stream && stream->status == TEGRADRM_STREAM_CONSTRUCT)) {
+        ErrorMsg("Stream status isn't CONSTRUCT\n");
+        return -1;
+    }
+
+    ret = drm_tegra_pushbuf_sync(stream->buffer.pushbuf, cond);
+    if (ret != 0) {
+        stream->status = TEGRADRM_STREAM_CONSTRUCTION_FAILED;
+        ErrorMsg("drm_tegra_pushbuf_sync() failed %d\n", ret);
+        return -1;
+    }
+
+    if (cond == DRM_TEGRA_SYNCPT_COND_OP_DONE)
+        stream->op_done_synced = true;
 
     return 0;
 }

--- a/src/tegra_stream.h
+++ b/src/tegra_stream.h
@@ -28,6 +28,7 @@
 #ifndef TEGRA_STREAM_H_
 #define TEGRA_STREAM_H_
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <libdrm/tegra.h>
 
@@ -51,6 +52,8 @@ struct tegra_stream {
     struct tegra_command_buffer buffer;
     int num_words;
     uint32_t class_id;
+
+    bool op_done_synced;
 };
 
 struct tegra_reloc {
@@ -79,5 +82,7 @@ struct tegra_reloc tegra_reloc(const void *var_ptr, struct drm_tegra_bo *bo,
 int tegra_stream_push_words(struct tegra_stream *stream, const void *addr,
                             unsigned words, int num_relocs, ...);
 int tegra_stream_prep(struct tegra_stream *stream, uint32_t words);
+int tegra_stream_sync(struct tegra_stream *stream,
+                      enum drm_tegra_syncpt_cond cond);
 
 #endif


### PR DESCRIPTION
Arto Merilainen of NVIDIA confirmed that we should increment syncpoint
after each HW trigger because it might be not safe to adjust registers
while operation hasn't completed yet, let's do it.