### PR TITLE
dri2: Forbid caching of the exported BO

### DIFF
--- a/src/dri2.c
+++ b/src/dri2.c
@@ -180,6 +180,8 @@ tegra_dri2_create_buffer(DrawablePtr drawable, unsigned int attachment,
         return NULL;
     }
 
+    drm_tegra_bo_forbid_caching(tegra->bo);
+
     buffer->pitch = pixmap->devKind;
     buffer->driverPrivate = private;
     private->refcnt = 1;


### PR DESCRIPTION
libdrm-tegra doesn't forbid caching after getting FLINK name of BO anymore, caching should be forbidden explicitly now.