### PR TITLE
driver: check whether XF86_PDEV_SERVER_FD is defined

### DIFF
--- a/src/driver.c
+++ b/src/driver.c
@@ -238,12 +238,14 @@ TegraProbeHardware(const char *dev, struct xf86_platform_device *platform_dev)
     int fd;
 
 #if XSERVER_PLATFORM_BUS
+#ifdef XF86_PDEV_SERVER_FD
     if (platform_dev && (platform_dev->flags & XF86_PDEV_SERVER_FD)) {
         fd = xf86_get_platform_device_int_attrib(platform_dev, ODEV_ATTRIB_FD, -1);
         if (fd == -1)
             return FALSE;
         return TRUE;
     }
+#endif
 #endif
 
     fd = TegraOpenHardware(dev);


### PR DESCRIPTION
This should fix building with older Xorg versions.

../../src/driver.c: In function ‘TegraProbeHardware’:
../../src/driver.c:241:38: error: ‘struct xf86_platform_device’ has no member named ‘flags’
     if (platform_dev && (platform_dev->flags & XF86_PDEV_SERVER_FD)) {
                                      ^
../../src/driver.c:241:48: error: ‘XF86_PDEV_SERVER_FD’ undeclared (first use in this function)
     if (platform_dev && (platform_dev->flags & XF86_PDEV_SERVER_FD)) {
                                                ^
../../src/driver.c:241:48: note: each undeclared identifier is reported only once for each function it appears in
../../src/driver.c:242:9: error: implicit declaration of function ‘xf86_get_platform_device_int_attrib’ [-Werror=implicit-function-declaration]
         fd = xf86_get_platform_device_int_attrib(platform_dev, ODEV_ATTRIB_FD, -1);
         ^
../../src/driver.c:242:9: warning: nested extern declaration of ‘xf86_get_platform_device_int_attrib’ [-Wnested-externs]
../../src/driver.c:242:64: error: ‘ODEV_ATTRIB_FD’ undeclared (first use in this function)
         fd = xf86_get_platform_device_int_attrib(platform_dev, ODEV_ATTRIB_FD, -1);

Signed-off-by: Dmitry Osipenko <digetx@gmail.com>