### PR TITLE
driver: s/if/ifdef/ for XSERVER_PLATFORM_BUS

### DIFF
--- a/src/driver.c
+++ b/src/driver.c
@@ -237,7 +237,7 @@ TegraProbeHardware(const char *dev, struct xf86_platform_device *platform_dev)
 {
     int fd;
 
-#if XSERVER_PLATFORM_BUS
+#ifdef XSERVER_PLATFORM_BUS
 #ifdef XF86_PDEV_SERVER_FD
     if (platform_dev && (platform_dev->flags & XF86_PDEV_SERVER_FD)) {
         fd = xf86_get_platform_device_int_attrib(platform_dev, ODEV_ATTRIB_FD, -1);


### PR DESCRIPTION
We actually want to check that it is defined and not != 0. That also makes this check consistent with other checks for XSERVER_PLATFORM_BUS in the code.