### PR TITLE
exa: unset fence pointer on pixmap data release

### DIFF
--- a/src/exa.c
+++ b/src/exa.c
@@ -499,6 +499,7 @@ static void TegraEXAReleasePixmapData(TegraPixmapPtr priv)
     if (priv->fence) {
         TegraEXAWaitFence(priv->fence);
         tegra_stream_put_fence(priv->fence);
+        priv->fence = NULL;
     }
 
     if (priv->pool_ptr) {


### PR DESCRIPTION
I'm not exactly sure when ModifyPixmapHeader could be invoked, so better
to just clear the pointer.