### PR TITLE
exa: re-use allocated BO for 3d attributes

### DIFF
--- a/src/driver.c
+++ b/src/driver.c
@@ -542,6 +542,7 @@ TegraCloseScreen(CLOSE_SCREEN_ARGS_DECL)
 
     xf86_cursors_fini(pScreen);
     TegraDRI2ScreenExit(pScreen);
+    TegraXvScreenExit(pScreen);
     TegraVBlankScreenExit(pScreen);
     TegraEXAScreenExit(pScreen);
 

--- a/src/driver.h
+++ b/src/driver.h
@@ -196,6 +196,7 @@ typedef struct _TegraRec
 #define TegraPTR(p) ((TegraPtr)((p)->driverPrivate))
 
 Bool TegraXvScreenInit(ScreenPtr pScreen);
+void TegraXvScreenExit(ScreenPtr pScreen);
 
 Bool TegraEXAScreenInit(ScreenPtr pScreen);
 void TegraEXAScreenExit(ScreenPtr pScreen);

--- a/src/driver.h
+++ b/src/driver.h
@@ -183,6 +183,8 @@ typedef struct _TegraRec
 
     struct drm_tegra *drm;
 
+    Bool xv_blocks_hw_cursor;
+
     Bool exa_compress_png;
     int exa_compress_jpeg_quality;
     Bool exa_compress_jpeg;

--- a/src/drmmode_display.c
+++ b/src/drmmode_display.c
@@ -348,6 +348,9 @@ drmmode_load_cursor_argb_check(xf86CrtcPtr crtc, CARD32 *image)
     uint32_t *ptr;
     static Bool first_time = TRUE;
 
+    if (tegra->xv_blocks_hw_cursor)
+        return FALSE;
+
     /* cursor should be mapped already */
     ptr = (uint32_t *) (drmmode_crtc->cursor_bo->ptr);
 

--- a/src/xv.c
+++ b/src/xv.c
@@ -1064,6 +1064,7 @@ static int TegraVideoOverlayGetAttribute(ScrnInfoPtr scrn, Atom attribute,
 
 static void TegraVideoOverlayStop(ScrnInfoPtr scrn, void *data, Bool cleanup)
 {
+    TegraPtr tegra     = TegraPTR(scrn);
     TegraVideoPtr priv = data;
     int id;
 
@@ -1079,6 +1080,11 @@ static void TegraVideoOverlayStop(ScrnInfoPtr scrn, void *data, Bool cleanup)
                                      FALSE, TRUE);
 
         TegraVideoOverlaySetCSC(priv, scrn, csc_default_blob_id, TRUE);
+    }
+
+    if (tegra->xv_blocks_hw_cursor) {
+        tegra->xv_blocks_hw_cursor = FALSE;
+        xf86CursorResetCursor(scrn->pScreen);
     }
 }
 
@@ -1491,6 +1497,11 @@ static Bool TegraVideoOverlayPutImageOnOverlays(TegraVideoPtr priv,
         ErrorMsg("TegraDrmModeAtomicCommit failed: %d (%s)\n",
                  err, strerror(-err));
         return FALSE;
+    }
+
+    if (!tegra->xv_blocks_hw_cursor) {
+        tegra->xv_blocks_hw_cursor = TRUE;
+        xf86CursorResetCursor(scrn->pScreen);
     }
 
     return TRUE;

--- a/src/xv.c
+++ b/src/xv.c
@@ -572,10 +572,13 @@ static Bool TegraVideoOverlayInitialize(TegraVideoPtr priv, ScrnInfoPtr scrn,
 
     res = drmModeGetResources(tegra->fd);
     if (!res) {
-        return FALSE;
+        ErrorMsg("drmModeGetResources failed\n");
+        success = FALSE;
+        goto end;
     }
 
     if (overlay_id > res->count_crtcs) {
+        ErrorMsg("Invalid overlay_id %u:%u\n", overlay_id, res->count_crtcs);
         success = FALSE;
         goto end;
     }
@@ -1315,8 +1318,10 @@ Bool TegraXvScreenInit(ScreenPtr pScreen)
     if (!TegraXvGetDrmProps(scrn, priv))
         goto err_free_adaptor;
 
-    if (!xf86XVScreenInit(pScreen, &xvAdaptor, 1))
+    if (!xf86XVScreenInit(pScreen, &xvAdaptor, 1)) {
+        ErrorMsg("xf86XVScreenInit failed\n");
         goto err_free_adaptor;
+    }
 
     xf86DrvMsg(scrn->scrnIndex, X_INFO, "XV adaptor initialized\n");
 

--- a/src/xv.c
+++ b/src/xv.c
@@ -113,6 +113,10 @@ static XF86ImageRec XvImages[] = {
 
 static XF86VideoFormatRec XvFormats[] = {
     {
+        .depth = 16,
+        .class = TrueColor,
+    },
+    {
         .depth = 24,
         .class = TrueColor,
     },


### PR DESCRIPTION
Avoid unnecessary attributes BO reallocations by re-using the currently allocated BO and by keeping one attributes BO always allocated.