### PR TITLE
Accelerated  memcpy

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -64,7 +64,8 @@ opentegra_drv_la_SOURCES = \
 	shaders.h \
 	gr3d.c \
 	gr3d.h \
-	pool_alloc.c
+	pool_alloc.c \
+	memcpy_vfp.c
 
 shaders_dir := $(filter %/, $(wildcard $(srcdir)/shaders/*/))
 shaders_gen := $(addsuffix .bin.h, $(shaders_dir:%/=%))

--- a/src/driver.h
+++ b/src/driver.h
@@ -116,6 +116,7 @@
 #include "tgr_3d.xml.h"
 #include "shaders/prog.h"
 #include "gr3d.h"
+#include "memcpy_vfp.h"
 
 #ifdef LONG64
 #  define FMT_CARD32 "x"

--- a/src/exa_mm.c
+++ b/src/exa_mm.c
@@ -48,12 +48,13 @@ Bool TegraEXAAllocateDRM(TegraPtr tegra,
 
 Bool TegraEXAAllocateMem(TegraPixmapPtr pixmap, unsigned int size)
 {
+    int err;
+
     if (pixmap->dri)
         return FALSE;
 
-    pixmap->fallback = malloc(size);
-
-    if (!pixmap->fallback)
+    err = posix_memalign(&pixmap->fallback, 128, size);
+    if (err)
         return FALSE;
 
     pixmap->type = TEGRA_EXA_PIXMAP_TYPE_FALLBACK;

--- a/src/exa_mm_fridge.c
+++ b/src/exa_mm_fridge.c
@@ -274,7 +274,8 @@ static void TegraEXAResurrectAccelPixmap(TegraPtr tegra, TegraPixmapPtr pixmap)
     }
 
     if (pixmap_data) {
-        memcpy(pixmap_data, pixmap_data_orig, data_size);
+        tegra_memcpy_vfp_aligned_src_cached(pixmap_data, pixmap_data_orig,
+                                            data_size);
         TegraEXAFridgeUnMapPixmap(pixmap);
         free(pixmap_data_orig);
         exa->release_count++;
@@ -407,11 +408,10 @@ uncompressed:
         return 1;
     }
 
-    c->buf_out = malloc(c->in_size);
-
-    if (c->buf_out) {
+    err = posix_memalign(&c->buf_out, 128, c->in_size);
+    if (!err) {
         c->compression_type = TEGRA_EXA_COMPRESSION_UNCOMPRESSED;
-        memcpy(c->buf_out, c->buf_in, c->in_size);
+        tegra_memcpy_vfp_aligned_dst_cached(c->buf_out, c->buf_in, c->in_size);
 
         c->out_size = c->in_size;
     }
@@ -433,7 +433,7 @@ static void TegraEXADecompressPixmap(TegraEXAPtr exa, struct compression_arg *c)
 
     switch (c->compression_type) {
     case TEGRA_EXA_COMPRESSION_UNCOMPRESSED:
-        memcpy(c->buf_out, c->buf_in, c->out_size);
+        tegra_memcpy_vfp_aligned_src_cached(c->buf_out, c->buf_in, c->out_size);
 
         free(c->buf_in);
         break;

--- a/src/memcpy_vfp.c
+++ b/src/memcpy_vfp.c
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) Dmitry Osipenko
+ * Copyright (c) Erik Faye-Lund
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include <stdbool.h>
+
+#include "memcpy_vfp.h"
+
+#define BLOCK_SIZE  1024
+
+static __thread char bounce_buf[BLOCK_SIZE] __attribute__((aligned (128)));
+
+static inline void vfpcpy(void *dst, const void *src, int size)
+{
+    asm volatile(
+        "   .fpu vfpv3-d16          \n\t"
+        "   .arch armv7a            \n\t"
+        "0:                         \n\t"
+        "   subs  %2, %2, #64       \n\t"
+        "   vldm  %1!, {d0-d7}      \n\t"
+        "   pld   [%1, #0]          \n\t"
+        "   pld   [%1, #32]         \n\t"
+        "   vstm  %0!, {d0-d7}      \n\t"
+        "   bgt   0b                \n\t"
+        : "+r" (dst), "+r" (src), "+r" (size)
+        :
+        : "cc");
+}
+
+void tegra_copy_block_vfp(void *dst, const void *src, int size)
+{
+    vfpcpy(dst, src, size);
+}
+
+void tegra_copy_block_vfp_2_pass(char *dst, const char *src, int size)
+{
+    int i, dir, block_size = BLOCK_SIZE;
+    const char *psrc = src;
+    char *pdst = dst;
+    bool move = true;
+
+    if ((uintptr_t)dst + size <= (uintptr_t)src ||
+        (uintptr_t)src + size <= (uintptr_t)dst)
+            move = false;
+
+    do {
+        if (size <= block_size) {
+            block_size = size;
+            move = false;
+        }
+
+        dir = (pdst > psrc && move) ? -1 : 1;
+
+        if (dir < 0) {
+            psrc += size - block_size;
+            pdst += size - block_size;
+        }
+
+        for (i = 0; i < size / block_size; i++) {
+            vfpcpy(bounce_buf, psrc, block_size);
+            memcpy(pdst, bounce_buf, block_size);
+
+            psrc += block_size * dir;
+            pdst += block_size * dir;
+        }
+
+        size -= block_size * i;
+
+        if (dst > pdst)
+            pdst = dst;
+
+        if (src > psrc)
+            psrc = src;
+
+    } while (size);
+}
+
+void tegra_copy_block_vfp_arm(char *dst, const char *src, int size)
+{
+    asm volatile(
+        "   .fpu vfpv3-d16          \n\t"
+        "   .arch armv7a            \n\t"
+        "0:                         \n\t"
+        "   vldm  %1!, {d0-d15}     \n\t"
+        "   subs  %2, %2, #128      \n\t"
+        "   beq   1f                \n\t"
+        "   pld   [%1, #0]          \n\t"
+        "   pld   [%1, #32]         \n\t"
+        "   pld   [%1, #64]         \n\t"
+        "   pld   [%1, #96]         \n\t"
+        "1:                         \n\t"
+        "   push  {%1, %2}          \n\t"
+        "   vmov  %1, %2, d0        \n\t"
+        "   stmia %0!, {%1, %2}     \n\t"
+        "   vmov  %1, %2, d1        \n\t"
+        "   stmia %0!, {%1, %2}     \n\t"
+        "   vmov  %1, %2, d2        \n\t"
+        "   stmia %0!, {%1, %2}     \n\t"
+        "   vmov  %1, %2, d3        \n\t"
+        "   stmia %0!, {%1, %2}     \n\t"
+        "   vmov  %1, %2, d4        \n\t"
+        "   stmia %0!, {%1, %2}     \n\t"
+        "   vmov  %1, %2, d5        \n\t"
+        "   stmia %0!, {%1, %2}     \n\t"
+        "   vmov  %1, %2, d6        \n\t"
+        "   stmia %0!, {%1, %2}     \n\t"
+        "   vmov  %1, %2, d7        \n\t"
+        "   stmia %0!, {%1, %2}     \n\t"
+        "   vmov  %1, %2, d8        \n\t"
+        "   stmia %0!, {%1, %2}     \n\t"
+        "   vmov  %1, %2, d9        \n\t"
+        "   stmia %0!, {%1, %2}     \n\t"
+        "   vmov  %1, %2, d10       \n\t"
+        "   stmia %0!, {%1, %2}     \n\t"
+        "   vmov  %1, %2, d11       \n\t"
+        "   stmia %0!, {%1, %2}     \n\t"
+        "   vmov  %1, %2, d12       \n\t"
+        "   stmia %0!, {%1, %2}     \n\t"
+        "   vmov  %1, %2, d13       \n\t"
+        "   stmia %0!, {%1, %2}     \n\t"
+        "   vmov  %1, %2, d14       \n\t"
+        "   stmia %0!, {%1, %2}     \n\t"
+        "   vmov  %1, %2, d15       \n\t"
+        "   stmia %0!, {%1, %2}     \n\t"
+        "   pop  {%1, %2}           \n\t"
+        "   bgt   0b                \n\t"
+        : "+r" (dst), "+r" (src), "+r" (size)
+        :
+        : "cc", "d8", "d9", "d10", "d11", "d12", "d13", "d14", "d15");
+}
+
+void tegra_memcpy_vfp_unaligned_2_pass(char *dst, const char *src, int size)
+{
+    int bytes_align = (uintptr_t)src & 127;
+    bool bounce;
+
+    /* having dst bouncing instead of src is always more efficient */
+    if (bytes_align) {
+        int offset = 128 - bytes_align;
+
+        memcpy(dst, src, offset);
+
+        src += offset;
+        dst += offset;
+        size -= offset;
+    }
+
+    bytes_align = (uintptr_t)dst & 127;
+    bounce = bytes_align > 0;
+
+    while (size > 127) {
+        int block_size = size & ~127;
+
+        if (block_size > BLOCK_SIZE)
+            block_size = BLOCK_SIZE;
+
+        if (bounce) {
+            tegra_copy_block_vfp_arm(bounce_buf, src, block_size);
+            memcpy(dst, bounce_buf, block_size);
+        } else {
+            vfpcpy(dst, src, block_size);
+        }
+
+        src += block_size;
+        dst += block_size;
+        size -= block_size;
+    }
+
+    if (size)
+        memcpy(dst, src, size);
+}

--- a/src/memcpy_vfp.h
+++ b/src/memcpy_vfp.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Dmitry Osipenko
+ * Copyright (c) Erik Faye-Lund
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef __TEGRA_MEMCPY_H
+#define __TEGRA_MEMCPY_H
+
+#include <assert.h>
+#include <stdint.h>
+#include <string.h>
+
+void tegra_copy_block_vfp(void *dst, const void *src, int size);
+void tegra_copy_block_vfp_2_pass(char *dst, const char *src, int size);
+void tegra_copy_block_vfp_arm(char *dst, const char *src, int size);
+void tegra_memcpy_vfp_unaligned_2_pass(char *dst, const char *src, int size);
+
+static inline void
+tegra_memcpy_vfp_unaligned(void *dst, const void *src, int size)
+{
+    if (size < 192)
+        memcpy(dst, src, size);
+    else
+        tegra_memcpy_vfp_unaligned_2_pass(dst, src, size);
+}
+
+/* use this when both src and dst are either cacheable or uncacheable */
+static inline void
+tegra_memcpy_vfp_aligned(void *dst, const void *src, int size)
+{
+    if (__builtin_expect(dst == src || !size, 0))
+        return;
+
+    assert(((uintptr_t)src & 127) == 0);
+    assert(((uintptr_t)dst & 127) == 0);
+    assert((size & 127) == 0);
+    assert(size > 128);
+
+    tegra_copy_block_vfp_2_pass(dst, src, size);
+}
+
+/* use this when src is uncacheable and dst is cacheable */
+static inline void
+tegra_memcpy_vfp_aligned_dst_cached(void *dst, const void *src, int size)
+{
+    if (__builtin_expect(dst == src || !size, 0))
+        return;
+
+    assert(((uintptr_t)src & 127) == 0);
+    assert(((uintptr_t)dst & 127) == 0);
+    assert((size & 127) == 0);
+    assert(size > 128);
+
+    tegra_copy_block_vfp(dst, src, size);
+}
+
+/* use this when src is cacheable and dst uncacheable */
+static inline void
+tegra_memcpy_vfp_aligned_src_cached(void *dst, const void *src, int size)
+{
+    if (__builtin_expect(dst == src || !size, 0))
+        return;
+
+    assert(((uintptr_t)src & 127) == 0);
+    assert(((uintptr_t)dst & 127) == 0);
+    assert((size & 127) == 0);
+    assert(size > 128);
+
+    tegra_copy_block_vfp_arm(dst, src, size);
+}
+
+#define tegra_memmove_vfp_aligned(d,s,z)    tegra_memcpy_vfp_aligned(d,s,z)
+
+#endif

--- a/src/pool_alloc.c
+++ b/src/pool_alloc.c
@@ -27,6 +27,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "pool_alloc.h"
+#include "memcpy_vfp.h"
 
 #ifdef POOL_DEBUG
 static struct {
@@ -304,9 +305,9 @@ static void migrate_entry(struct mem_pool *pool_from,
 #endif
     move_entry(pool_from, pool_to, from, to);
     if (new_base != pool_to->entries[to].base) {
-        memmove(new_base,
-                pool_to->entries[to].base,
-                pool_to->entries[to].size);
+        tegra_memmove_vfp_aligned(new_base,
+                                  pool_to->entries[to].base,
+                                  pool_to->entries[to].size);
         mem_pool_clear_canary(&pool_to->entries[to]);
         pool_to->entries[to].base = new_base;
     }


### PR DESCRIPTION
Add accelerated  memcpy that uses VFP instructions to copy 128 bytes at once, it gives significant boost to copying from uncached buffer. Inspired by results of https://github.com/ssvb/tinymembench.

> ==========================================================================
== Framebuffer read tests.                                              ==
==                                                                      ==
== Many ARM devices use a part of the system memory as the framebuffer, ==
== typically mapped as uncached but with write-combining enabled.       ==
== Writes to such framebuffers are quite fast, but reads are much       ==
== slower and very sensitive to the alignment and the selection of      ==
== CPU instructions which are used for accessing memory.                ==
==                                                                      ==
== Many x86 systems allocate the framebuffer in the GPU memory,         ==
== accessible for the CPU via a relatively slow PCI-E bus. Moreover,    ==
== PCI-E is asymmetric and handles reads a lot worse than writes.       ==
==                                                                      ==
== If uncached framebuffer reads are reasonably fast (at least 100 MB/s ==
== or preferably >300 MB/s), then using the shadow framebuffer layer    ==
== is not necessary in Xorg DDX drivers, resulting in a nice overall    ==
== performance improvement. For example, the xf86-video-fbturbo DDX     ==
== uses this trick.                                                     ==
==========================================================================
 VFP copy (from framebuffer)                          :    436.1 MB/s (1.7%)
 VFP 2-pass copy (from framebuffer)                   :    392.8 MB/s (1.3%)
 ARM copy (from framebuffer)                          :    285.8 MB/s (1.8%)
 ARM 2-pass copy (from framebuffer)                   :    274.5 MB/s (1.2%)
 standard memcpy (from framebuffer)                   :     86.3 MB/s (0.5%)
