### PR TITLE
Xv non-blocking VDPAU API

### DIFF
--- a/src/driver.c
+++ b/src/driver.c
@@ -493,7 +493,7 @@ static Bool
 SetMaster(ScrnInfoPtr pScrn)
 {
     TegraPtr tegra = TegraPTR(pScrn);
-    int ret;
+    int ret, err;
 
 #ifdef XF86_PDEV_SERVER_FD
     if (tegra->pEnt->location.type == BUS_PLATFORM &&
@@ -505,6 +505,11 @@ SetMaster(ScrnInfoPtr pScrn)
     if (ret)
         xf86DrvMsg(pScrn->scrnIndex, X_ERROR, "drmSetMaster failed: %s\n",
                    strerror(errno));
+
+    err = drmSetClientCap(tegra->fd, DRM_CLIENT_CAP_ATOMIC, 1);
+    if (err < 0)
+        xf86DrvMsg(pScrn->scrnIndex, X_ERROR, "drmSetClientCap failed: %s\n",
+                   strerror(err));
 
     return ret == 0;
 }

--- a/src/drm_plane.c
+++ b/src/drm_plane.c
@@ -24,7 +24,7 @@
 
 #include "driver.h"
 
-#define HANDLE_INVALID  UINT32_MAX
+#define HANDLE_INVALID  0
 
 #define MUNMAP_VERBOSE(PTR, SIZE)                       \
     if (PTR && munmap(PTR, page_align(SIZE)) != 0)      \
@@ -195,28 +195,31 @@ static drm_overlay_fb * drm_create_fb_internal(int drm_fd, uint32_t drm_format,
     if (from_handle)
         goto create_framebuffer;
 
-    bo_handles = alloca(sizeof(uint32_t) * 3);
+    bo_handles = alloca(sizeof(uint32_t) * 4);
     if (!bo_handles)
         return NULL;
 
-    pitches = alloca(sizeof(uint32_t) * 3);
+    pitches = alloca(sizeof(uint32_t) * 4);
     if (!pitches)
         return NULL;
 
-    offsets = alloca(sizeof(uint32_t) * 3);
+    offsets = alloca(sizeof(uint32_t) * 4);
     if (!offsets)
         return NULL;
 
     pitches[0] = fb_pitch(drm_format, width);
     pitches[1] = fb_pitch_c(drm_format, width);
     pitches[2] = fb_pitch_c(drm_format, width);
+    pitches[3] = 0;
 
     offsets[0] = 0;
     offsets[1] = 0;
     offsets[2] = 0;
+    offsets[3] = 0;
 
     bo_handles[1] = HANDLE_INVALID;
     bo_handles[2] = HANDLE_INVALID;
+    bo_handles[3] = HANDLE_INVALID;
 
     /* Allocate PLANE[0] */
     bo_handles[0] = create_gem(drm_fd, fb_size(drm_format, width, height));

--- a/src/xv.h
+++ b/src/xv.h
@@ -35,6 +35,13 @@
 #define FOURCC_PASSTHROUGH_XRGB8888 (('X' << 24) + ('B' << 16) + ('G' << 8) + 'R')
 #define FOURCC_PASSTHROUGH_XBGR8888 (('X' << 24) + ('R' << 16) + ('G' << 8) + 'B')
 
+#define PASSTHROUGH_DATA_SIZE_V2 128
+
+#define FOURCC_PASSTHROUGH_YV12_V2     (('T' << 24) + ('G' << 16) + ('R' << 8) + '1')
+#define FOURCC_PASSTHROUGH_RGB565_V2   (('T' << 24) + ('G' << 16) + ('R' << 8) + '2')
+#define FOURCC_PASSTHROUGH_XRGB8888_V2 (('T' << 24) + ('G' << 16) + ('R' << 8) + '3')
+#define FOURCC_PASSTHROUGH_XBGR8888_V2 (('T' << 24) + ('G' << 16) + ('R' << 8) + '4')
+
 #define XVMC_YV12                                   \
 {                                                   \
     .id                 = FOURCC_PASSTHROUGH_YV12,  \
@@ -125,6 +132,118 @@
     .type               = XvRGB,                    \
     .byte_order         = LSBFirst,                 \
     .guid               = {'P', 'A', 'S', 'S', 'T', 'H', 'R', 'O', 'U', 'G', 'H', 'B', 'G', 'R', '3', '2'}, \
+    .bits_per_pixel     = 32,                       \
+    .format             = XvPacked,                 \
+    .num_planes         = 1,                        \
+    /* for RGB formats only */                      \
+    .depth              = 24,                       \
+    .red_mask           = 0xff <<  0,               \
+    .green_mask         = 0xff <<  8,               \
+    .blue_mask          = 0xff << 16,               \
+    /* for YUV formats only */                      \
+    .y_sample_bits      = 0,                        \
+    .u_sample_bits      = 0,                        \
+    .v_sample_bits      = 0,                        \
+    .horz_y_period      = 0,                        \
+    .horz_u_period      = 0,                        \
+    .horz_v_period      = 0,                        \
+    .vert_y_period      = 0,                        \
+    .vert_u_period      = 0,                        \
+    .vert_v_period      = 0,                        \
+    .component_order    = {'R', 'G', 'B', 'X', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, \
+    .scanline_order     = XvTopToBottom,            \
+}
+
+#define XVMC_YV12_V2                                \
+{                                                   \
+    .id                 = FOURCC_PASSTHROUGH_YV12_V2,\
+    .type               = XvYUV,                    \
+    .byte_order         = LSBFirst,                 \
+    .guid               = {'P', 'A', 'S', 'S', 'T', 'H', 'R', 'O', 'U', 'G', 'H', '_', 'T', 'G', 'R', '1'}, \
+    .bits_per_pixel     = 12,                       \
+    .format             = XvPlanar,                 \
+    .num_planes         = 3,                        \
+    /* for RGB formats only */                      \
+    .depth              = 0,                        \
+    .red_mask           = 0,                        \
+    .green_mask         = 0,                        \
+    .blue_mask          = 0,                        \
+    /* for YUV formats only */                      \
+    .y_sample_bits      = 8,                        \
+    .u_sample_bits      = 8,                        \
+    .v_sample_bits      = 8,                        \
+    .horz_y_period      = 1,                        \
+    .horz_u_period      = 2,                        \
+    .horz_v_period      = 2,                        \
+    .vert_y_period      = 1,                        \
+    .vert_u_period      = 1,                        \
+    .vert_v_period      = 2,                        \
+    .component_order    = {'Y', 'V', 'U', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, \
+    .scanline_order     = XvTopToBottom,            \
+}
+
+#define XVMC_RGB565_V2                              \
+{                                                   \
+    .id                 = FOURCC_PASSTHROUGH_RGB565_V2,\
+    .type               = XvRGB,                    \
+    .byte_order         = LSBFirst,                 \
+    .guid               = {'P', 'A', 'S', 'S', 'T', 'H', 'R', 'O', 'U', 'G', 'H', '_', 'T', 'G', 'R', '2'}, \
+    .bits_per_pixel     = 16,                       \
+    .format             = XvPacked,                 \
+    .num_planes         = 1,                        \
+    /* for RGB formats only */                      \
+    .depth              = 16,                       \
+    .red_mask           = 0x1f << 11,               \
+    .green_mask         = 0x3f <<  5,               \
+    .blue_mask          = 0x1f <<  0,               \
+    /* for YUV formats only */                      \
+    .y_sample_bits      = 0,                        \
+    .u_sample_bits      = 0,                        \
+    .v_sample_bits      = 0,                        \
+    .horz_y_period      = 0,                        \
+    .horz_u_period      = 0,                        \
+    .horz_v_period      = 0,                        \
+    .vert_y_period      = 0,                        \
+    .vert_u_period      = 0,                        \
+    .vert_v_period      = 0,                        \
+    .component_order    = {'B', 'G', 'R', 'X', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, \
+    .scanline_order     = XvTopToBottom,            \
+}
+
+#define XVMC_XRGB8888_V2                            \
+{                                                   \
+    .id                 = FOURCC_PASSTHROUGH_XRGB8888_V2,\
+    .type               = XvRGB,                    \
+    .byte_order         = LSBFirst,                 \
+    .guid               = {'P', 'A', 'S', 'S', 'T', 'H', 'R', 'O', 'U', 'G', 'H', '_', 'T', 'G', 'R', '3'}, \
+    .bits_per_pixel     = 32,                       \
+    .format             = XvPacked,                 \
+    .num_planes         = 1,                        \
+    /* for RGB formats only */                      \
+    .depth              = 24,                       \
+    .red_mask           = 0xff << 16,               \
+    .green_mask         = 0xff <<  8,               \
+    .blue_mask          = 0xff <<  0,               \
+    /* for YUV formats only */                      \
+    .y_sample_bits      = 0,                        \
+    .u_sample_bits      = 0,                        \
+    .v_sample_bits      = 0,                        \
+    .horz_y_period      = 0,                        \
+    .horz_u_period      = 0,                        \
+    .horz_v_period      = 0,                        \
+    .vert_y_period      = 0,                        \
+    .vert_u_period      = 0,                        \
+    .vert_v_period      = 0,                        \
+    .component_order    = {'B', 'G', 'R', 'X', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, \
+    .scanline_order     = XvTopToBottom,            \
+}
+
+#define XVMC_XBGR8888_V2                            \
+{                                                   \
+    .id                 = FOURCC_PASSTHROUGH_XBGR8888_V2,\
+    .type               = XvRGB,                    \
+    .byte_order         = LSBFirst,                 \
+    .guid               = {'P', 'A', 'S', 'S', 'T', 'H', 'R', 'O', 'U', 'G', 'H', '_', 'T', 'G', 'R', '4'}, \
     .bits_per_pixel     = 32,                       \
     .format             = XvPacked,                 \
     .num_planes         = 1,                        \


### PR DESCRIPTION
Add new alternative non-blocking API which doesn't block Xorg on updating plane's state. Later we may transit to async atomic updates, once DRM core will expose async commits to userspace and Tegra DRM will support it too (grate-kernel has it https://github.com/grate-driver/linux/commit/bb12b422f376614ada8abf8d5a122a0b2b5acaeb, I'll send it out to upstream soon'ish).

I'm going to merge this PR couple days later, after some more testing and if there won't be any objections. WIP VDPAU patch is [here](https://github.com/digetx/libvdpau-tegra/commit/6e82b2ec7c4175dc4b12bf790c88687d585c22c6).