### PR TITLE
Ignore screen initialization errors

### DIFF
--- a/src/dri2.c
+++ b/src/dri2.c
@@ -838,6 +838,8 @@ Bool TegraDRI2ScreenInit(ScreenPtr screen)
 
     tegra->dri2_enabled = TRUE;
 
+    xf86DrvMsg(scrn->scrnIndex, X_INFO, "DRI2 initialized\n");
+
     return TRUE;
 }
 

--- a/src/driver.c
+++ b/src/driver.c
@@ -670,20 +670,14 @@ TegraScreenInit(SCREEN_INIT_ARGS_DECL)
 
     xf86SetBlackWhitePixels(pScreen);
 
-    if (!TegraEXAScreenInit(pScreen))
-        return FALSE;
+    TegraEXAScreenInit(pScreen);
 
     if (!TegraScreenXf86Init(pScreen))
         return FALSE;
 
-    if (!TegraXvScreenInit(pScreen))
-        return FALSE;
-
-    if (!TegraVBlankScreenInit(pScreen))
-        return FALSE;
-
-    if (!TegraDRI2ScreenInit(pScreen))
-        return FALSE;
+    TegraXvScreenInit(pScreen);
+    TegraVBlankScreenInit(pScreen);
+    TegraDRI2ScreenInit(pScreen);
 
     if (!miCreateDefColormap(pScreen))
         return FALSE;

--- a/src/exa.c
+++ b/src/exa.c
@@ -671,6 +671,8 @@ Bool TegraEXAScreenInit(ScreenPtr pScreen)
         goto release_mm;
     }
 
+    xf86DrvMsg(pScrn->scrnIndex, X_INFO, "EXA initialized\n");
+
     priv->driver = exa;
     tegra->exa = priv;
 

--- a/src/vblank.c
+++ b/src/vblank.c
@@ -315,6 +315,8 @@ TegraVBlankScreenInit(ScreenPtr screen)
                                    tegra_drm_wakeup_handler, screen);
 #endif
 
+    xf86DrvMsg(scrn->scrnIndex, X_INFO, "VBLANK initialized\n");
+
     return TRUE;
 }
 

--- a/src/xv.c
+++ b/src/xv.c
@@ -1315,5 +1315,7 @@ Bool TegraXvScreenInit(ScreenPtr pScreen)
 err_free_adaptor:
     free(adaptor);
 
+    ErrorMsg("XV initialization failed\n");
+
     return FALSE;
 }


### PR DESCRIPTION
In commit 4c602ea I completely forgot about legit cases where EXA intialization may fail. This PR contains  fix and two minor clean-up patches.