### PR TITLE
Minor update

### DIFF
--- a/src/driver.c
+++ b/src/driver.c
@@ -441,7 +441,7 @@ static Bool
 SetMaster(ScrnInfoPtr pScrn)
 {
     TegraPtr tegra = TegraPTR(pScrn);
-    int ret, err;
+    int ret, err, err2 = 0;
 
 #ifdef XF86_PDEV_SERVER_FD
     if (tegra->pEnt->location.type == BUS_PLATFORM &&
@@ -454,10 +454,13 @@ SetMaster(ScrnInfoPtr pScrn)
         xf86DrvMsg(pScrn->scrnIndex, X_ERROR, "drmSetMaster failed: %s\n",
                    strerror(errno));
 
-    err = drmSetClientCap(tegra->fd, DRM_CLIENT_CAP_ATOMIC, 1);
+    err = drmSetClientCap(tegra->fd, DRM_CLIENT_CAP_ATOMIC, 2);
     if (err < 0)
-        xf86DrvMsg(pScrn->scrnIndex, X_ERROR, "drmSetClientCap failed: %s\n",
-                   strerror(err));
+        err2 = drmSetClientCap(tegra->fd, DRM_CLIENT_CAP_ATOMIC, 1);
+
+    if (err < 0 && err2 < 0)
+        xf86DrvMsg(pScrn->scrnIndex, X_ERROR, "drmSetClientCap failed: %s %s\n",
+                   strerror(err), strerror(err2));
 
     return ret == 0;
 }

--- a/src/exa.c
+++ b/src/exa.c
@@ -122,7 +122,7 @@ static void TegraEXAWaitMarker(ScreenPtr pScreen, int marker)
         tegra->scratch.marker = NULL;
 }
 
-Bool TegraEXAPrepareCPUAccess(PixmapPtr pPix, int idx, void **ptr)
+static Bool TegraEXAPrepareCPUAccess(PixmapPtr pPix, int idx, void **ptr)
 {
     TegraPixmapPtr priv = exaGetPixmapDriverPrivate(pPix);
     int err;

--- a/src/xv.c
+++ b/src/xv.c
@@ -1181,6 +1181,16 @@ TegraXvGetDrmPlaneProperty(ScrnInfoPtr scrn,
     }
 
     ErrorMsg("Failed to get \"%s\" property\n", prop_name);
+    ErrorMsg("Available properties:\n");
+
+    for (i = 0; i < properties->count_props; i++) {
+        property = drmModeGetProperty(tegra->fd, properties->props[i]);
+        if (!property)
+            continue;
+
+        ErrorMsg("\t\"%s\"\n", property->name);
+        free(property);
+    }
 
     *prop_id = 0;
 

--- a/src/xv.c
+++ b/src/xv.c
@@ -124,6 +124,12 @@ static XF86VideoFormatRec XvFormats[] = {
 
 static XF86AttributeRec XvAttributes[] = {
     {
+        .flags      = XvGettable,
+        .min_value  = 1,
+        .max_value  = 1,
+        .name       = (char *)"XV_SUPPORTS_DISP_ROTATION",
+    },
+    {
         .flags      = XvSettable | XvGettable,
         .min_value  = 0,
         .max_value  = 0xFFFFFF,


### PR DESCRIPTION
- the DRM atomic API is disabled now for Xorg in [Linux kernel](    https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=26b1d3b527e7bf3e24b814d617866ac5199ce68d
), but Opentegra needs it for Xv
- libvdpau-tegra now will be able to perform better when display is rotated
