### PR TITLE
opentegra_lib: include time.h

### DIFF
--- a/src/tegradrm/opentegra_lib.h
+++ b/src/tegradrm/opentegra_lib.h
@@ -28,6 +28,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <time.h>
 
 #include "lists.h"
 #include "opentegra_drm.h"


### PR DESCRIPTION
- musl-libc doesn't include it by default

Signed-off-by: David Heidelberg <david@ixit.cz>

Fixes: https://github.com/grate-driver/xf86-video-opentegra/issues/61